### PR TITLE
Use non-blocking mode for loki docker logging driver

### DIFF
--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -6,6 +6,7 @@ x-logging:
   driver: loki
   options:
     loki-url: "http://127.0.0.1:9110/loki/api/v1/push"
+    mode: non-blocking  # https://github.com/grafana/loki/issues/2361
     loki-pipeline-stages: |
       - multiline:
           firstline: '^\d{2}:\d{2}:\d{2}\.\d{3} \[(?P<thread>[\w\d\-.]+)\] (?P<level>\w+)'

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -81,6 +81,7 @@ class ContainerManager(private val settings: DockerSettings) {
                             LogConfig.LoggingType.LOKI,
                             mapOf(
                                 // similar to config in docker-compose.yaml
+                                "mode" to "non-blocking",
                                 "loki-url" to "http://127.0.0.1:9110/loki/api/v1/push",
                                 "loki-external-labels" to "container_name={{.Name}},source=save-agent"
                             )


### PR DESCRIPTION
### What's done:
* Updated docker-compose.yaml.template
* Updated ContainerManager.kt

This should help to prevent freezing of container, when loki server is unavailable