### PR TITLE
Frontend: Add view with verbose test execution data

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
@@ -2,6 +2,7 @@ package org.cqfn.save.backend.controllers
 
 import org.cqfn.save.agent.TestExecutionDto
 import org.cqfn.save.backend.service.TestExecutionService
+import org.cqfn.save.domain.TestResultLocation
 import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.test.TestDto
 import org.slf4j.LoggerFactory
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 /**
  * Controller to work with test execution
@@ -49,6 +51,20 @@ class TestExecutionController(private val testExecutionService: TestExecutionSer
                                             @PathVariable status: TestResultStatus
     ) = testExecutionService.getTestExecutions(agentContainerId, status)
         .map { it.toDto() }
+
+    /**
+     * Finds TestExecution by test location, returns 404 if not found
+     *
+     * @param executionId under this executionId test has been executed
+     * @param testResultLocation location of the test
+     * @return TestExecution
+     */
+    @PostMapping("/testExecutions")
+    fun getTestExecutionByLocation(@RequestParam executionId: Long,
+                                   @RequestBody testResultLocation: TestResultLocation,
+    ): TestExecutionDto = testExecutionService.getTestExecution(executionId, testResultLocation)
+        .map { it.toDto() }
+        .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Test execution not found for executionId=$executionId and $testResultLocation") }
 
     /**
      * Returns number of TestExecutions with this [executionId]

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
@@ -7,6 +7,7 @@ import org.cqfn.save.backend.repository.TestDataFilesystemRepository
 import org.cqfn.save.backend.repository.TestExecutionRepository
 import org.cqfn.save.backend.repository.TestRepository
 import org.cqfn.save.backend.utils.secondsToLocalDateTime
+import org.cqfn.save.domain.TestResultLocation
 import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.entities.TestExecution
 import org.cqfn.save.test.TestDto
@@ -15,7 +16,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.pathString
 
 /**
  * Service for test result
@@ -50,6 +53,19 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
      */
     internal fun getTestExecutions(agentContainerId: String, status: TestResultStatus) = testExecutionRepository
         .findByAgentContainerIdAndStatus(agentContainerId, status)
+
+    /**
+     * Finds TestExecution by test location
+     *
+     * @param executionId under this executionId test has been executed
+     * @param testResultLocation location of the test
+     * @return optional TestExecution
+     */
+    internal fun getTestExecution(executionId: Long, testResultLocation: TestResultLocation) = with(testResultLocation) {
+        testExecutionRepository.findByExecutionIdAndTestPluginNameAndTestFilePath(
+            executionId, pluginName, Paths.get(testLocation, testName).pathString
+        )
+    }
 
     /**
      * Returns number of TestExecutions with this [executionId]

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -13,6 +13,7 @@ import org.cqfn.save.frontend.components.views.ExecutionView
 import org.cqfn.save.frontend.components.views.FallbackView
 import org.cqfn.save.frontend.components.views.HistoryView
 import org.cqfn.save.frontend.components.views.ProjectView
+import org.cqfn.save.frontend.components.views.testExecutionDetailsView
 import org.cqfn.save.frontend.externals.fontawesome.faAngleUp
 import org.cqfn.save.frontend.externals.fontawesome.faCheck
 import org.cqfn.save.frontend.externals.fontawesome.faCogs
@@ -33,7 +34,6 @@ import react.RBuilder
 import react.RComponent
 import react.State
 import react.buildElement
-import react.child
 import react.dom.div
 import react.dom.render
 import react.react
@@ -132,6 +132,13 @@ class App : RComponent<PropsWithChildren, AppState>() {
                                     }
                                 }
                             }
+                        }
+                        Route {
+                            attrs {
+                                path = arrayOf("/:owner/:name/history/execution/:executionId/details/:testSuiteName/:pluginName/:testFilePath")
+                                exact = false  // all paths parts under testFilePath should be captured
+                            }
+                            child(testExecutionDetailsView()) { }
                         }
                         Route {
                             attrs {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/TestStatusComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/TestStatusComponent.kt
@@ -33,7 +33,6 @@ import kotlinx.browser.window
 @Suppress("TOO_LONG_FUNCTION")
 @OptIn(ExperimentalFileSystem::class)
 fun <D : Any> testStatusComponent(testResultDebugInfo: TestResultDebugInfo, tableInstance: TableInstance<D>) = fc<Props> {
-    // todo: also display execCmd here
     val shortMessage: String = when (val status = testResultDebugInfo.testStatus) {
         is Pass -> (status.shortMessage ?: "").ifBlank { "Completed successfully without additional information" }
         is Fail -> status.shortReason

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -12,6 +12,7 @@ import org.cqfn.save.frontend.components.basic.executionStatistics
 import org.cqfn.save.frontend.components.basic.executionTestsNotFound
 import org.cqfn.save.frontend.components.basic.testStatusComponent
 import org.cqfn.save.frontend.components.tables.tableComponent
+import org.cqfn.save.frontend.http.getDebugInfoFor
 import org.cqfn.save.frontend.themes.Colors
 import org.cqfn.save.frontend.utils.decodeFromJsonString
 import org.cqfn.save.frontend.utils.get
@@ -44,7 +45,6 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import kotlinx.html.js.onClickFunction
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /**
@@ -160,13 +160,7 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
                             attrs.onClickFunction = {
                                 GlobalScope.launch {
                                     val te = cellProps.value
-                                    val trdi = post(
-                                        "${window.location.origin}/files/get-debug-info",
-                                        Headers().apply {
-                                            set("Content-Type", "application/json")
-                                        },
-                                        Json.encodeToString(te)
-                                    )
+                                    val trdi = getDebugInfoFor(te)
                                     if (trdi.ok) {
                                         cellProps.row.original.asDynamic().debugInfo = trdi.decodeFromJsonString<TestResultDebugInfo>()
                                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
@@ -70,10 +70,10 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
         }
         with(testResultDebugInfo.debugInfo!!) {
             listOf(
-                "stdout" to stdout,
-                "stderr" to stderr
+                "stdout" to ::stdout,
+                "stderr" to ::stderr
             )
-        }.forEach { (title, content) ->
+        }.forEach { (title, getContent) ->
             tr {
                 td {
                     +title
@@ -81,7 +81,7 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
                 td {
                     small {
                         samp {
-                            content?.let(::multilineTextWithIndices)
+                            getContent()?.let(::multilineTextWithIndices)
                                 ?: +"N/A"
                         }
                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
@@ -2,10 +2,15 @@
 
 package org.cqfn.save.frontend.components.views
 
+import org.cqfn.save.core.result.Crash
+import org.cqfn.save.core.result.Fail
+import org.cqfn.save.core.result.Ignored
+import org.cqfn.save.core.result.Pass
 import org.cqfn.save.domain.TestResultDebugInfo
 import org.cqfn.save.domain.TestResultLocation
 import org.cqfn.save.frontend.http.getDebugInfoFor
 import org.cqfn.save.frontend.utils.decodeFromJsonString
+import org.cqfn.save.frontend.utils.multilineText
 import org.cqfn.save.frontend.utils.post
 
 import org.w3c.fetch.Headers
@@ -13,7 +18,6 @@ import react.Props
 import react.RBuilder
 import react.dom.ReactHTML.div
 import react.dom.ReactHTML.tbody
-import react.dom.br
 import react.dom.samp
 import react.dom.small
 import react.dom.table
@@ -40,9 +44,23 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
             td {
                 small {
                     samp {
-                        testResultDebugInfo.debugInfo?.execCmd
+                        +(testResultDebugInfo.debugInfo?.execCmd ?: "N/A")
                     }
                 }
+            }
+        }
+        tr {
+            td {
+                +"Test status"
+            }
+            td {
+                val longMessage: String = when (val status = testResultDebugInfo.testStatus) {
+                    is Pass -> (status.message ?: "").ifBlank { "Completed successfully without additional information" }
+                    is Fail -> status.reason
+                    is Ignored -> status.reason
+                    is Crash -> status.description
+                }
+                multilineText(longMessage)
             }
         }
         with(testResultDebugInfo.debugInfo!!) {
@@ -58,10 +76,7 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
                 td {
                     small {
                         samp {
-                            content?.lines()?.forEach {
-                                +it
-                                br { }
-                            }
+                            content?.let(::multilineText)
                                 ?: +"N/A"
                         }
                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
@@ -1,0 +1,128 @@
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package org.cqfn.save.frontend.components.views
+
+import org.cqfn.save.domain.TestResultDebugInfo
+import org.cqfn.save.domain.TestResultLocation
+import org.cqfn.save.frontend.http.getDebugInfoFor
+import org.cqfn.save.frontend.utils.decodeFromJsonString
+import org.cqfn.save.frontend.utils.post
+
+import org.w3c.fetch.Headers
+import react.Props
+import react.RBuilder
+import react.dom.ReactHTML.div
+import react.dom.ReactHTML.tbody
+import react.dom.br
+import react.dom.samp
+import react.dom.small
+import react.dom.table
+import react.dom.td
+import react.dom.tr
+import react.fc
+import react.router.dom.useParams
+import react.useEffect
+import react.useState
+
+import kotlinx.browser.window
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Suppress("TOO_LONG_FUNCTION", "EMPTY_BLOCK_STRUCTURE_ERROR")
+private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = table {
+    react.dom.ReactHTML.tbody {
+        tr {
+            td {
+                +"Command"
+            }
+            td {
+                small {
+                    samp {
+                        testResultDebugInfo.debugInfo?.execCmd
+                    }
+                }
+            }
+        }
+        with(testResultDebugInfo.debugInfo!!) {
+            listOf(
+                "stdout" to stdout,
+                "stderr" to stderr
+            )
+        }.forEach { (title, content) ->
+            tr {
+                td {
+                    +title
+                }
+                td {
+                    small {
+                        samp {
+                            content?.lines()?.forEach {
+                                +it
+                                br { }
+                            }
+                                ?: +"N/A"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun RBuilder.fallback(status: String) = div {
+    +status
+}
+
+/**
+ * A component to display details about test execution
+ *
+ * @return a function component
+ */
+@Suppress("GENERIC_VARIABLE_WRONG_DECLARATION", "TOO_LONG_FUNCTION")
+fun testExecutionDetailsView() = fc<Props> {
+    val params = useParams()
+    val executionId = params["executionId"]!!.toLong()
+    val testResultLocation = TestResultLocation(
+        params["testSuiteName"]!!,
+        params["pluginName"]!!,
+        params["testFilePath"]!!.substringBeforeLast("/", ""),
+        params["testFilePath"]!!.substringAfterLast("/"),
+    )
+
+    val (status, setStatus) = useState("Loading...")
+    val (testResultDebugInfo, setTestResultDebugInfo) = useState<TestResultDebugInfo?>(null)
+
+    // fixme: after https://github.com/diktat-static-analysis/save-cloud/issues/364 can be passed via history state to avoid requests
+    useEffect(listOf<dynamic>(executionId, testResultLocation)) {
+        GlobalScope.launch {
+            val testExecutionDtoResponse = post(
+                "${window.location.origin}/testExecutions?executionId=$executionId",
+                Headers().apply {
+                    set("Content-Type", "application/json")
+                },
+                Json.encodeToString(testResultLocation)
+            )
+            if (testExecutionDtoResponse.ok) {
+                val testResultDebugInfoResponse = getDebugInfoFor(testExecutionDtoResponse.decodeFromJsonString())
+                if (testResultDebugInfoResponse.ok) {
+                    setTestResultDebugInfo(
+                        testResultDebugInfoResponse.decodeFromJsonString<TestResultDebugInfo>()
+                    )
+                } else {
+                    setStatus("Additional test info is not available (code ${testResultDebugInfoResponse.status})")
+                }
+            } else {
+                setStatus("Additional test info is not available (code ${testExecutionDtoResponse.status})")
+            }
+        }
+    }
+
+    testResultDebugInfo?.let {
+        resultsTable(testResultDebugInfo)
+    }
+        ?: run {
+            fallback(status)
+        }
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/TestExecutionDetailsView.kt
@@ -11,6 +11,7 @@ import org.cqfn.save.domain.TestResultLocation
 import org.cqfn.save.frontend.http.getDebugInfoFor
 import org.cqfn.save.frontend.utils.decodeFromJsonString
 import org.cqfn.save.frontend.utils.multilineText
+import org.cqfn.save.frontend.utils.multilineTextWithIndices
 import org.cqfn.save.frontend.utils.post
 
 import org.w3c.fetch.Headers
@@ -18,6 +19,7 @@ import react.Props
 import react.RBuilder
 import react.dom.ReactHTML.div
 import react.dom.ReactHTML.tbody
+import react.dom.br
 import react.dom.samp
 import react.dom.small
 import react.dom.table
@@ -35,8 +37,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Suppress("TOO_LONG_FUNCTION", "EMPTY_BLOCK_STRUCTURE_ERROR")
-private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = table {
-    react.dom.ReactHTML.tbody {
+private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = table("table table-bordered") {
+    tbody {
         tr {
             td {
                 +"Command"
@@ -54,12 +56,15 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
                 +"Test status"
             }
             td {
-                val longMessage: String = when (val status = testResultDebugInfo.testStatus) {
+                val status = testResultDebugInfo.testStatus
+                val longMessage: String = when (status) {
                     is Pass -> (status.message ?: "").ifBlank { "Completed successfully without additional information" }
                     is Fail -> status.reason
                     is Ignored -> status.reason
                     is Crash -> status.description
                 }
+                +"${status::class.simpleName} with message:"
+                br { }
                 multilineText(longMessage)
             }
         }
@@ -76,7 +81,7 @@ private fun RBuilder.resultsTable(testResultDebugInfo: TestResultDebugInfo) = ta
                 td {
                     small {
                         samp {
-                            content?.let(::multilineText)
+                            content?.let(::multilineTextWithIndices)
                                 ?: +"N/A"
                         }
                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/http/Requests.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/http/Requests.kt
@@ -1,0 +1,28 @@
+/**
+ * Methods to make specific requests to backend
+ */
+
+package org.cqfn.save.frontend.http
+
+import org.cqfn.save.agent.TestExecutionDto
+import org.cqfn.save.frontend.utils.post
+
+import org.w3c.fetch.Headers
+
+import kotlinx.browser.window
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Fetch debug info for test execution
+ *
+ * @param testExecutionDto
+ * @return Response
+ */
+suspend fun getDebugInfoFor(testExecutionDto: TestExecutionDto) = post(
+    "${window.location.origin}/files/get-debug-info",
+    Headers().apply {
+        set("Content-Type", "application/json")
+    },
+    Json.encodeToString(testExecutionDto)
+)

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
@@ -9,6 +9,8 @@ import org.cqfn.save.domain.FileInfo
 import org.w3c.files.Blob
 import org.w3c.files.BlobPropertyBag
 import org.w3c.xhr.FormData
+import react.RBuilder
+import react.dom.br
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -41,3 +43,16 @@ inline fun <reified T> FormData.appendJson(name: String, obj: T) =
                 BlobPropertyBag("application/json")
             )
         )
+
+/**
+ * Adds this text to RBuilder line by line, separating with `<br>`
+ *
+ * @param text text to display
+ */
+@Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")
+internal fun RBuilder.multilineText(text: String) {
+    text.lines().forEach {
+        +it
+        br { }
+    }
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
@@ -11,6 +11,12 @@ import org.w3c.files.BlobPropertyBag
 import org.w3c.xhr.FormData
 import react.RBuilder
 import react.dom.br
+import react.dom.samp
+import react.dom.small
+import react.dom.table
+import react.dom.tbody
+import react.dom.td
+import react.dom.tr
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -52,7 +58,31 @@ inline fun <reified T> FormData.appendJson(name: String, obj: T) =
 @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")
 internal fun RBuilder.multilineText(text: String) {
     text.lines().forEach {
-        +it
+        small {
+            samp {
+                +it
+            }
+        }
         br { }
+    }
+}
+
+/**
+ * @param text
+ */
+internal fun RBuilder.multilineTextWithIndices(text: String) {
+    table("table table-borderless table-hover table-sm") {
+        tbody {
+            text.lines().filterNot { it.isEmpty() }.forEachIndexed { i, line ->
+                tr {
+                    td {
+                        +"${i + 1}"
+                    }
+                    td {
+                        +line
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### What's done:
* Added endpoint in TestExecutionController
* Created Requests.kt for common HTTP requests
* Added TestExecutionDetailsView

![image](https://user-images.githubusercontent.com/23018090/139871904-28b66528-ad9a-41ac-ae0b-df1faca8714a.png)

Continuation of #183 , closes #368