### PR TITLE
Hotfix: Capture filePath as repeated parameter

### DIFF
--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -135,7 +135,7 @@ class App : RComponent<PropsWithChildren, AppState>() {
                         }
                         Route {
                             attrs {
-                                path = arrayOf("/:owner/:name/history/execution/:executionId/details/:testSuiteName/:pluginName/:testFilePath")
+                                path = arrayOf("/:owner/:name/history/execution/:executionId/details/:testSuiteName/:pluginName/:testFilePath+")
                                 exact = false  // all paths parts under testFilePath should be captured
                             }
                             child(testExecutionDetailsView()) { }


### PR DESCRIPTION
Other than `exact = false`, react-router requires regex-like setting for repeated params group