### PR TITLE
Hotfix: schedule job only if not already scheduled

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/scheduling/StandardSuitesUpdateScheduler.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/scheduling/StandardSuitesUpdateScheduler.kt
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import java.time.Duration
-import java.util.Date
 import javax.annotation.PostConstruct
 
 /**
@@ -59,7 +58,11 @@ class StandardSuitesUpdateScheduler(
      * @return when the job will be executed for the first time
      */
     @PostConstruct
-    fun schedule(): Date = scheduler.scheduleJob(jobDetail, trigger)
+    fun schedule() {
+        if (!scheduler.checkExists(jobDetail.key)) {
+            scheduler.scheduleJob(jobDetail, trigger)
+        }
+    }
 
     companion object {
         internal val jobName = UpdateJob::class.simpleName


### PR DESCRIPTION
### What's done:
* Fix in `StandardSuitesUpdateScheduler`

After https://github.com/diktat-static-analysis/save-cloud/commit/20c706873213ca1c8166d26338ced7cb7b5e1e04 quartz scheduler doesn't start with the following error:
```
Caused by: org.quartz.ObjectAlreadyExistsException: Unable to store Job : 'DEFAULT.UpdateJob', because one already exists with this identification.
```

I wasn't able to figure out, why it wasn't crashing before, because newer spring boot (2.5.4 -> 2.6.0) uses the same version of quartz, 2.3.2.