### PR TITLE
Bugfix: Keep original file permissions when making recursive copy

### DIFF
--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
@@ -4,6 +4,10 @@
 
 package org.cqfn.save.orchestrator
 
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
 /**
  * @param hostname hostname to be resolved via `hosts` file
  * @return IP address of [hostname] if it has been found or null
@@ -21,4 +25,25 @@ fun getHostIp(hostname: String): String? {
         .lines()
         .firstOrNull()
         ?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * Copy [sourceDir] into [targetDir] recursively, while also copying original file attributes
+ *
+ * @param sourceDir source directory
+ * @param targetDir target directory
+ */
+fun copyRecursivelyWithAttributes(sourceDir: File, targetDir: File) {
+    sourceDir.walkTopDown().forEach { source ->
+        val target = targetDir.resolve(source.relativeTo(sourceDir)).canonicalFile
+        if (source.isDirectory) {
+            target.mkdirs()
+        }
+        Files.copy(
+            source.toPath(),
+            target.toPath(),
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.COPY_ATTRIBUTES,
+        )
+    }
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -14,6 +14,7 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import com.github.dockerjava.transport.DockerHttpClient
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 
 import java.io.BufferedOutputStream
@@ -132,7 +133,7 @@ class ContainerManager(private val settings: DockerSettings) {
                                          runCmd: String = "RUN /bin/bash",
     ): String {
         val tmpDir = createTempDirectory().toFile()
-        baseDir.copyRecursively(File(tmpDir, "resources"))
+        FileUtils.copyDirectory(baseDir, tmpDir.resolve("resources"))
         val dockerFileAsText =
                 """
                     |FROM $baseImage

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -1,7 +1,7 @@
 package org.cqfn.save.orchestrator.docker
 
 import org.cqfn.save.orchestrator.config.DockerSettings
-import org.cqfn.save.orchestrator.currentSuiteDestination
+import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
 import org.cqfn.save.orchestrator.getHostIp
 
 import com.github.dockerjava.api.DockerClient

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -135,10 +135,14 @@ class ContainerManager(private val settings: DockerSettings) {
         val tmpDir = createTempDirectory().toFile()
         val tmpResourcesDir = tmpDir.absoluteFile.resolve("resources")
         log.debug("Copying ${baseDir.absolutePath} into $tmpResourcesDir")
-        baseDir.walkTopDown().forEach {
+        baseDir.walkTopDown().forEach { source ->
+            val target = tmpResourcesDir.resolve(source.relativeTo(baseDir)).canonicalFile
+            if (source.isDirectory) {
+                target.mkdirs()
+            }
             Files.copy(
-                it.toPath(),
-                tmpResourcesDir.resolve(it.relativeTo(baseDir)).canonicalFile.toPath(),
+                source.toPath(),
+                target.toPath(),
                 StandardCopyOption.COPY_ATTRIBUTES
             )
         }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -135,7 +135,7 @@ class ContainerManager(private val settings: DockerSettings) {
         val tmpDir = createTempDirectory().toFile()
         val tmpResourcesDir = tmpDir.absoluteFile.resolve("resources")
         log.debug("Copying ${baseDir.absolutePath} into $tmpResourcesDir")
-        baseDir.copyRecursivelyWithAttributes(tmpResourcesDir)
+        copyRecursivelyWithAttributes(baseDir, tmpResourcesDir)
         val dockerFileAsText =
                 """
                     |FROM $baseImage

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -143,7 +143,8 @@ class ContainerManager(private val settings: DockerSettings) {
             Files.copy(
                 source.toPath(),
                 target.toPath(),
-                StandardCopyOption.COPY_ATTRIBUTES
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.COPY_ATTRIBUTES,
             )
         }
         val dockerFileAsText =

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -133,9 +133,10 @@ class ContainerManager(private val settings: DockerSettings) {
                                          runCmd: String = "RUN /bin/bash",
     ): String {
         val tmpDir = createTempDirectory().toFile()
+        log.debug("Copying ${baseDir.absolutePath} into ${tmpDir.absolutePath}/resources")
         FileUtils.copyDirectory(baseDir, tmpDir.resolve("resources"))
-        tmpDir.resolve("resources").walkTopDown().forEach {
-            val copy = tmpDir.resolve("resources").resolve(it.relativeTo(baseDir)).toPath()
+        baseDir.walkTopDown().forEach {
+            val copy = tmpDir.resolve("resources").resolve(it.relativeTo(baseDir)).canonicalFile.toPath()
             log.debug("Changing permissions for $copy from ${Files.getPosixFilePermissions(copy)} to ${Files.getPosixFilePermissions(it.toPath())}")
             Files.setPosixFilePermissions(
                 copy,

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -134,6 +134,12 @@ class ContainerManager(private val settings: DockerSettings) {
     ): String {
         val tmpDir = createTempDirectory().toFile()
         FileUtils.copyDirectory(baseDir, tmpDir.resolve("resources"))
+        tmpDir.resolve("resources").walkTopDown().forEach {
+            Files.setPosixFilePermissions(
+                baseDir.resolve(it.relativeTo(tmpDir.resolve("resources"))).toPath(),
+                Files.getPosixFilePermissions(it.toPath())
+            )
+        }
         val dockerFileAsText =
                 """
                     |FROM $baseImage

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.orchestrator.docker
 
 import org.cqfn.save.orchestrator.config.DockerSettings
+import org.cqfn.save.orchestrator.currentSuiteDestination
 import org.cqfn.save.orchestrator.getHostIp
 
 import com.github.dockerjava.api.DockerClient
@@ -20,7 +21,6 @@ import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.util.zip.GZIPOutputStream
 
 import kotlin.io.path.ExperimentalPathApi
@@ -135,18 +135,7 @@ class ContainerManager(private val settings: DockerSettings) {
         val tmpDir = createTempDirectory().toFile()
         val tmpResourcesDir = tmpDir.absoluteFile.resolve("resources")
         log.debug("Copying ${baseDir.absolutePath} into $tmpResourcesDir")
-        baseDir.walkTopDown().forEach { source ->
-            val target = tmpResourcesDir.resolve(source.relativeTo(baseDir)).canonicalFile
-            if (source.isDirectory) {
-                target.mkdirs()
-            }
-            Files.copy(
-                source.toPath(),
-                target.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.COPY_ATTRIBUTES,
-            )
-        }
+        baseDir.copyRecursivelyWithAttributes(tmpResourcesDir)
         val dockerFileAsText =
                 """
                     |FROM $baseImage

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -135,8 +135,10 @@ class ContainerManager(private val settings: DockerSettings) {
         val tmpDir = createTempDirectory().toFile()
         FileUtils.copyDirectory(baseDir, tmpDir.resolve("resources"))
         tmpDir.resolve("resources").walkTopDown().forEach {
+            val copy = tmpDir.resolve("resources").resolve(it.relativeTo(baseDir)).toPath()
+            log.debug("Changing permissions for $copy from ${Files.getPosixFilePermissions(copy)} to ${Files.getPosixFilePermissions(it.toPath())}")
             Files.setPosixFilePermissions(
-                baseDir.resolve(it.relativeTo(tmpDir.resolve("resources"))).toPath(),
+                copy,
                 Files.getPosixFilePermissions(it.toPath())
             )
         }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -262,11 +262,11 @@ class DockerService(private val configProperties: ConfigProperties) {
                 )
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
-            FileUtils.copyDirectory(standardTestSuiteAbsolutePath, currentSuiteDestination)
-            standardTestSuiteAbsolutePath.walkTopDown().forEach {
-                Files.setPosixFilePermissions(
-                    currentSuiteDestination.resolve(it.relativeTo(standardTestSuiteAbsolutePath)).toPath(),
-                    Files.getPosixFilePermissions(it.toPath())
+            standardTestSuiteAbsolutePath.walkTopDown().forEach { source ->
+                Files.copy(
+                    source.toPath(),
+                    currentSuiteDestination.resolve(source.relativeTo(standardTestSuiteAbsolutePath)).toPath(),
+                    StandardCopyOption.COPY_ATTRIBUTES
                 )
             }
         }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -263,7 +263,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                 )
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
-            standardTestSuiteAbsolutePath.copyRecursivelyWithAttributes(currentSuiteDestination)
+            copyRecursivelyWithAttributes(standardTestSuiteAbsolutePath, currentSuiteDestination)
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
         val lookupService = destination.toPath().fileSystem.userPrincipalLookupService

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -5,6 +5,7 @@ import org.cqfn.save.entities.Execution
 import org.cqfn.save.entities.TestSuite
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
+import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.orchestrator.docker.ContainerManager
 import org.cqfn.save.testsuite.TestSuiteDto
@@ -262,18 +263,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                 )
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
-            standardTestSuiteAbsolutePath.walkTopDown().forEach { source ->
-                val target = currentSuiteDestination.resolve(source.relativeTo(standardTestSuiteAbsolutePath)).canonicalFile
-                if (source.isDirectory) {
-                    target.mkdirs()
-                }
-                Files.copy(
-                    source.toPath(),
-                    target.toPath(),
-                    StandardCopyOption.REPLACE_EXISTING,
-                    StandardCopyOption.COPY_ATTRIBUTES,
-                )
-            }
+            standardTestSuiteAbsolutePath.copyRecursivelyWithAttributes(currentSuiteDestination)
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
         val lookupService = destination.toPath().fileSystem.userPrincipalLookupService

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -263,9 +263,13 @@ class DockerService(private val configProperties: ConfigProperties) {
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
             standardTestSuiteAbsolutePath.walkTopDown().forEach { source ->
+                val target = currentSuiteDestination.resolve(source.relativeTo(standardTestSuiteAbsolutePath)).canonicalFile
+                if (source.isDirectory) {
+                    target.mkdirs()
+                }
                 Files.copy(
                     source.toPath(),
-                    currentSuiteDestination.resolve(source.relativeTo(standardTestSuiteAbsolutePath)).toPath(),
+                    target.toPath(),
                     StandardCopyOption.COPY_ATTRIBUTES
                 )
             }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -270,7 +270,8 @@ class DockerService(private val configProperties: ConfigProperties) {
                 Files.copy(
                     source.toPath(),
                     target.toPath(),
-                    StandardCopyOption.COPY_ATTRIBUTES
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.COPY_ATTRIBUTES,
                 )
             }
         }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -262,7 +262,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                 )
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
-            standardTestSuiteAbsolutePath.copyRecursively(currentSuiteDestination, overwrite = true)
+            FileUtils.copyDirectory(standardTestSuiteAbsolutePath, currentSuiteDestination)
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
         val lookupService = destination.toPath().fileSystem.userPrincipalLookupService

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -263,6 +263,12 @@ class DockerService(private val configProperties: ConfigProperties) {
             val currentSuiteDestination = destination.resolve("$PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE${it.testSuiteRepoUrl.hashCode()}_${it.testRootPath.hashCode()}")
             log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $currentSuiteDestination/...")
             FileUtils.copyDirectory(standardTestSuiteAbsolutePath, currentSuiteDestination)
+            standardTestSuiteAbsolutePath.walkTopDown().forEach {
+                Files.setPosixFilePermissions(
+                    currentSuiteDestination.resolve(it.relativeTo(standardTestSuiteAbsolutePath)).toPath(),
+                    Files.getPosixFilePermissions(it.toPath())
+                )
+            }
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
         val lookupService = destination.toPath().fileSystem.userPrincipalLookupService

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -5,8 +5,8 @@ import org.cqfn.save.entities.Execution
 import org.cqfn.save.entities.TestSuite
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
-import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
 import org.cqfn.save.orchestrator.config.ConfigProperties
+import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
 import org.cqfn.save.orchestrator.docker.ContainerManager
 import org.cqfn.save.testsuite.TestSuiteDto
 import org.cqfn.save.utils.PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE


### PR DESCRIPTION
Both `kotlin.io.copyRecursively` and `FileUtils.copyDirectory` discard file attributes. I didn't find any ready-to-use solution other than invoking `Files.copy` manually.

Closes #433 