### PR TITLE
Remove `STANDARD_` prefix from path when reading it in agent

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.5.31"
-save-core = "0.2.6"
+save-core = "0.3.0-SNAPSHOT"
 ktor = "1.6.5"
 okio = "3.0.0-alpha.10"
 serialization = "1.3.1"

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -229,7 +229,9 @@ class SaveAgent(internal val config: AgentConfiguration,
             readExecutionResults(jsonReport)
         }
         if (testExecutionDtos.isFailure) {
-            logError("Couldn't read execution results from JSON report, reason: ${testExecutionDtos.exceptionOrNull()?.describe()}")
+            logError("Couldn't read execution results from JSON report, reason: ${testExecutionDtos.exceptionOrNull()?.describe()}" +
+                    "\n${testExecutionDtos.exceptionOrNull()?.stackTraceToString()}"
+            )
         } else {
             sendDataToBackend {
                 postExecutionData(testExecutionDtos.getOrThrow())

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -13,6 +13,7 @@ import org.cqfn.save.domain.TestResultDebugInfo
 import org.cqfn.save.plugins.fix.FixPlugin
 import org.cqfn.save.reporter.Report
 import org.cqfn.save.utils.STANDARD_TEST_SUITE_DIR
+import org.cqfn.save.utils.adjustLocation
 import org.cqfn.save.utils.toTestResultDebugInfo
 import org.cqfn.save.utils.toTestResultStatus
 
@@ -41,7 +42,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import org.cqfn.save.utils.adjustLocation
 
 /**
  * A main class for SAVE Agent

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -157,7 +157,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                 // cliArgs could be not empty only in the Git mode and this variable contain the `testRootPath` + set of tests in this case
                 // in standard mode just use command, which we created in DockerService, it already contain all necessary configuration
                 if (!it.contains(STANDARD_TEST_SUITE_DIR)) "$it $cliArgs" else it
-            } + " --report-type json --result-output file",
+            } + " --report-type json --result-output file --log all",
             "",
             config.logFilePath.toPath(),
             100_000L

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
@@ -10,7 +10,6 @@ import org.cqfn.save.domain.TestResultLocation
 import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.entities.TestExecution
 import org.cqfn.save.test.TestDto
-import org.cqfn.save.utils.PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -124,16 +123,7 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
         val executionId = agent.execution.id!!
         val lostTests: MutableList<TestExecutionDto> = mutableListOf()
         val counters = Counters()
-        testExecutionsDtos.forEach {
-            // In standard mode we have extra paths in json reporter, since we created extra directories,
-            // and this information won't be matched with data from DB without such removement
-            val filePathWithDroppedPrefixForStandardMode = if (it.filePath.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
-                it.filePath.dropWhile { it != '/' }.drop(1)
-                // Use filePath as is for Git mode
-            } else {
-                it.filePath
-            }
-            val testExecDto = it.copy(filePath = filePathWithDroppedPrefixForStandardMode)
+        testExecutionsDtos.forEach { testExecDto ->
             val foundTestExec = testExecutionRepository.findByExecutionIdAndTestPluginNameAndTestFilePath(
                 executionId,
                 testExecDto.pluginName,

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
@@ -1,0 +1,60 @@
+/**
+ * Mapping entities from SAVE-core to their equivalents from SAVE-cloud
+ */
+
+package org.cqfn.save.utils
+
+import org.cqfn.save.core.logging.logTrace
+import org.cqfn.save.core.result.Crash
+import org.cqfn.save.core.result.Fail
+import org.cqfn.save.core.result.Ignored
+import org.cqfn.save.core.result.Pass
+import org.cqfn.save.core.result.TestResult
+import org.cqfn.save.core.result.TestStatus
+import org.cqfn.save.domain.TestResultDebugInfo
+import org.cqfn.save.domain.TestResultLocation
+import org.cqfn.save.domain.TestResultStatus
+
+import okio.ExperimentalFileSystem
+
+/**
+ * Maps `TestStatus` to `TestResultStatus`
+ */
+fun TestStatus.toTestResultStatus() = when (this) {
+    is Pass -> TestResultStatus.PASSED
+    is Fail -> TestResultStatus.FAILED
+    is Ignored -> TestResultStatus.IGNORED
+    is Crash -> TestResultStatus.TEST_ERROR
+    else -> error("Unknown test status $this")
+}
+
+/**
+ * Maps `TestResult` to `TestResultDebugInfo`
+ *
+ * @param testSuiteName name of the test suite
+ * @param pluginName name of the plugin that has been executed
+ * @return an instance of [TestResultDebugInfo] representing execution info
+ */
+@OptIn(ExperimentalFileSystem::class)
+fun TestResult.toTestResultDebugInfo(testSuiteName: String, pluginName: String): TestResultDebugInfo {
+    // In standard mode we have extra paths in json reporter, since we created extra directories,
+    // and this information won't be matched with data from DB without such removement
+    val location = resources.test.parent!!.toString()
+    val adjustedLocation = if (location.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
+        logTrace("Adjusting path to test file [$location/${resources.test.name}]: trimming $PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE")
+        location.dropWhile { it != '/' }.drop(1)
+    } else {
+        // Use filePath as is for Git mode
+        location
+    }
+    return TestResultDebugInfo(
+        TestResultLocation(
+            testSuiteName,
+            pluginName,
+            adjustedLocation,
+            resources.test.name
+        ),
+        debugInfo,
+        status,
+    )
+}

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
@@ -28,14 +28,6 @@ fun TestStatus.toTestResultStatus() = when (this) {
     else -> error("Unknown test status $this")
 }
 
-fun adjustLocation(location: String) = if (location.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
-    logTrace("Adjusting path to [$location]: trimming $PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE")
-    location.dropWhile { it != '/' }.drop(1)
-} else {
-    // Use filePath as is for Git mode
-    location
-}
-
 /**
  * Maps `TestResult` to `TestResultDebugInfo`
  *
@@ -59,4 +51,15 @@ fun TestResult.toTestResultDebugInfo(testSuiteName: String, pluginName: String):
         debugInfo,
         status,
     )
+}
+
+/**
+ * @param location location to be processed
+ */
+fun adjustLocation(location: String) = if (location.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
+    logTrace("Adjusting path to [$location]: trimming $PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE")
+    location.dropWhile { it != '/' }.drop(1)
+} else {
+    // Use filePath as is for Git mode
+    location
 }

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/utils/TestResultUtils.kt
@@ -39,14 +39,14 @@ fun TestResult.withAdjustedLocation(): TestResult {
     // In standard mode we have extra paths in json reporter, since we created extra directories,
     // and this information won't be matched with data from DB without such removal
     val location = resources.test.parent!!.toString()
-    val actualTestRoot = if (location.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
+    return if (location.startsWith(PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE)) {
         logTrace("Adjusting path to test file [$location/${resources.test.name}]: trimming $PREFIX_FOR_SUITES_LOCATION_IN_STANDARD_MODE")
-        location.dropWhile { it != '/' }.drop(1).toPath()
+        val actualTestRoot = location.split('/').first().toPath()
+        this.copy(resources = resources.withRelativePaths(actualTestRoot))
     } else {
         // Use filePath as is for Git mode
-        location.toPath()
+        this
     }
-    return this.copy(resources = resources.withRelativePaths(actualTestRoot))
 }
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
@@ -17,7 +17,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
  * @property executionLogs path to folder to store cli logs
  * @property shutdownChecksIntervalMillis interval between checks whether agents are really finished
  * @property aptExtraFlags additional flags that will be passed to `apt-get` when building image for tests
- * @property resourceOwner Linux user that will be set as owner of resources copied into docker build directory
+ * @property adjustResourceOwner whether Linux user that will be set as owner of resources copied into docker build directory
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "orchestrator")
@@ -29,7 +29,7 @@ data class ConfigProperties(
     val executionLogs: String,
     val shutdownChecksIntervalMillis: Long,
     val aptExtraFlags: String = "",
-    val resourceOwner: String = "cnb",
+    val adjustResourceOwner: Boolean = true,
 )
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
@@ -17,6 +17,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
  * @property executionLogs path to folder to store cli logs
  * @property shutdownChecksIntervalMillis interval between checks whether agents are really finished
  * @property aptExtraFlags additional flags that will be passed to `apt-get` when building image for tests
+ * @property resourceOwner Linux user that will be set as owner of resources copied into docker build directory
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "orchestrator")

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/ConfigProperties.kt
@@ -28,6 +28,7 @@ data class ConfigProperties(
     val executionLogs: String,
     val shutdownChecksIntervalMillis: Long,
     val aptExtraFlags: String = "",
+    val resourceOwner: String = "cnb",
 )
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -221,7 +221,7 @@ class DockerService(private val configProperties: ConfigProperties) {
             saveCli
         )
 
-        changeOwnerRecursively(resourcesPath, "cnb")
+        changeOwnerRecursively(resourcesPath, configProperties.resourceOwner)
 
         val baseImage = execution.sdk
         val aptCmd = "apt-get ${configProperties.aptExtraFlags}"

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -221,7 +221,9 @@ class DockerService(private val configProperties: ConfigProperties) {
             saveCli
         )
 
-        changeOwnerRecursively(resourcesPath, configProperties.resourceOwner)
+        if (configProperties.adjustResourceOwner) {
+            changeOwnerRecursively(resourcesPath, "cnb")
+        }
 
         val baseImage = execution.sdk
         val aptCmd = "apt-get ${configProperties.aptExtraFlags}"

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
@@ -123,9 +123,6 @@ class DockerServiceTest {
                 mockServer.start()
                 "http://localhost:${mockServer.port}"
             }
-            registry.add("orchestrator.resourceOwner") {
-                System.getProperty("user.name")
-            }
         }
     }
 }

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
@@ -123,6 +123,9 @@ class DockerServiceTest {
                 mockServer.start()
                 "http://localhost:${mockServer.port}"
             }
+            registry.add("orchestrator.resourceOwner") {
+                System.getProperty("user.name")
+            }
         }
     }
 }

--- a/save-orchestrator/src/test/resources/application.properties
+++ b/save-orchestrator/src/test/resources/application.properties
@@ -10,4 +10,5 @@ orchestrator.docker.host=unix:///var/run/docker.sock
 orchestrator.docker.loggingDriver=json
 orchestrator.docker.runtime=runsc
 orchestrator.agentsCount=1
+orchestrator.adjustResourceOwner=false
 logging.level.com.github.dockerjava.core.command=DEBUG

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -41,6 +41,7 @@ import org.springframework.http.ReactiveHttpOutputMessage
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.http.codec.multipart.FilePart
+import org.springframework.util.FileSystemUtils
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -63,12 +64,14 @@ import reactor.util.function.Tuple2
 
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.time.Duration
 
 import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createDirectories
 
 typealias Status = Mono<ResponseEntity<HttpStatus>>
 
@@ -379,16 +382,19 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
     internal fun generateDirectory(seeds: List<String>): File {
         val tmpDir = getTmpDirName(seeds)
         if (tmpDir.exists()) {
-            if (tmpDir.deleteRecursively()) {
-                log.info("For $seeds: dir $tmpDir was deleted")
-            } else {
-                error("Couldn't properly delete $tmpDir")
+            try {
+                if (FileSystemUtils.deleteRecursively(tmpDir.toPath())) {
+                    log.info("For $seeds: dir $tmpDir was deleted")
+                }
+            } catch (e: IOException) {
+                log.error("Couldn't properly delete $tmpDir", e)
             }
         }
-        if (tmpDir.mkdirs()) {
+        try {
+            tmpDir.toPath().createDirectories()
             log.info("For $seeds: dir $tmpDir was created")
-        } else {
-            error("Couldn't create directories for $tmpDir")
+        } catch (e: Exception) {
+            log.error("Couldn't create directories for $tmpDir", e)
         }
         return tmpDir
     }

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -379,6 +379,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
      * @param seeds a list of strings for directory name creation
      * @return a [File] representing the created temporary directory
      */
+    @Suppress("TooGenericExceptionCaught")
     internal fun generateDirectory(seeds: List<String>): File {
         val tmpDir = getTmpDirName(seeds)
         if (tmpDir.exists()) {


### PR DESCRIPTION
### What's done:
* Moved trimming of `STANDARD_` prefix from `TestExecutionService` to common utils
* Call it from Agent for both test results and debug info
* Fix setting owner/group in `DockerService`
* Add more logging in agent