### PR TITLE
Enable multithreading in save-agent

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
@@ -4,10 +4,10 @@
 
 package org.cqfn.save.agent
 
+import org.cqfn.save.agent.utils.logDebugCustom
+import org.cqfn.save.agent.utils.logInfoCustom
 import org.cqfn.save.agent.utils.readProperties
 import org.cqfn.save.core.config.LogType
-import org.cqfn.save.core.logging.logDebug
-import org.cqfn.save.core.logging.logInfo
 import org.cqfn.save.core.logging.logType
 
 import generated.SAVE_CLOUD_VERSION
@@ -29,8 +29,6 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import kotlinx.serialization.properties.Properties
 import kotlinx.serialization.properties.decodeFromStringMap
-import org.cqfn.save.agent.utils.logDebugCustom
-import org.cqfn.save.agent.utils.logInfoCustom
 
 internal val json = Json {
     serializersModule = SerializersModule {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
@@ -46,7 +46,7 @@ fun main() {
     val config: AgentConfiguration = Properties.decodeFromStringMap(
         readProperties("agent.properties")
     )
-    logType = if (config.debug) LogType.ALL else LogType.WARN
+    logType.set(if (config.debug) LogType.ALL else LogType.WARN)
     logDebugCustom("Instantiating save-agent version $SAVE_CLOUD_VERSION with config $config")
 
     signal(SIGTERM, staticCFunction<Int, Unit> {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
@@ -29,6 +29,8 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import kotlinx.serialization.properties.Properties
 import kotlinx.serialization.properties.decodeFromStringMap
+import org.cqfn.save.agent.utils.logDebugCustom
+import org.cqfn.save.agent.utils.logInfoCustom
 
 internal val json = Json {
     serializersModule = SerializersModule {
@@ -47,10 +49,10 @@ fun main() {
         readProperties("agent.properties")
     )
     logType = if (config.debug) LogType.ALL else LogType.WARN
-    logDebug("Instantiating save-agent version $SAVE_CLOUD_VERSION with config $config")
+    logDebugCustom("Instantiating save-agent version $SAVE_CLOUD_VERSION with config $config")
 
     signal(SIGTERM, staticCFunction<Int, Unit> {
-        logInfo("Agent is shutting down because SIGTERM has been received")
+        logInfoCustom("Agent is shutting down because SIGTERM has been received")
         exit(1)
     })
 
@@ -66,5 +68,5 @@ fun main() {
     runBlocking {
         saveAgent.start()
     }
-    logInfo("Agent is shutting down")
+    logInfoCustom("Agent is shutting down")
 }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -8,9 +8,6 @@ import org.cqfn.save.agent.utils.logInfoCustom
 import org.cqfn.save.agent.utils.readFile
 import org.cqfn.save.agent.utils.sendDataToBackend
 import org.cqfn.save.core.logging.describe
-import org.cqfn.save.core.logging.logDebug
-import org.cqfn.save.core.logging.logError
-import org.cqfn.save.core.logging.logInfo
 import org.cqfn.save.core.plugin.Plugin
 import org.cqfn.save.core.utils.ExecutionResult
 import org.cqfn.save.core.utils.ProcessBuilder
@@ -34,29 +31,22 @@ import okio.ExperimentalFileSystem
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
+import kotlin.coroutines.CoroutineContext
 import kotlin.native.concurrent.AtomicLong
 import kotlin.native.concurrent.AtomicReference
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import platform.posix.system
-import kotlin.coroutines.CoroutineContext
-import kotlin.native.concurrent.freeze
 
 /**
  * A main class for SAVE Agent
@@ -74,7 +64,7 @@ class SaveAgent(internal val config: AgentConfiguration,
     // fixme: can't use atomic reference to Instant here, because when using `Clock.System.now()` as an assined value
     // Kotlin throws `kotlin.native.concurrent.InvalidMutabilityException: mutation attempt of frozen kotlinx.datetime.Instant...`
     private val executionStartSeconds = AtomicLong()
-    private var saveProcessJob = AtomicReference<Job?>(null)
+    private var saveProcessJob: AtomicReference<Job?> = AtomicReference(null)
     private val reportFormat = Json {
         serializersModule = SerializersModule {
             polymorphic(Plugin.TestFiles::class) {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -81,7 +81,9 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
-        val heartbeatsJob = launch { startHeartbeats() }
+        val heartbeatsJob = launch(
+            newSingleThreadContext("save-execution")
+        ) { startHeartbeats() }
         heartbeatsJob.join()
     }
 

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -92,17 +92,6 @@ class SaveAgent(internal val config: AgentConfiguration,
     @Suppress("WHEN_WITHOUT_ELSE")  // when with sealed class
     private suspend fun startHeartbeats() = coroutineScope {
         logInfoCustom("Scheduling heartbeats")
-
-        runBlocking {
-            val job2 = async { delay(15_000); logInfoCustom("Hi, I'm in a second launch") }
-            val job1 = async(newSingleThreadContext("test-1")) {
-                logInfoCustom("Hi, I'm in a first launch")
-                system("sleep 10")
-                job2.cancel()
-            }
-            joinAll(job1, job2)
-        }
-
         sendDataToBackend { saveAdditionalData() }
         while (true) {
             val response = runCatching {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -82,15 +82,21 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
-        val heartbeatsJob = launch(
-            newSingleThreadContext("save-execution")
-        ) { startHeartbeats() }
+        val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()
     }
 
     @Suppress("WHEN_WITHOUT_ELSE")  // when with sealed class
     private suspend fun startHeartbeats() = coroutineScope {
         logInfoCustom("Scheduling heartbeats")
+
+        runBlocking {
+            launch(newSingleThreadContext("test-1")) {
+                logInfoCustom("Hi, I'm in a first launch")
+            }
+            logInfoCustom("Hi, I'm in a second launch")
+        }
+
         sendDataToBackend { saveAdditionalData() }
         while (true) {
             val response = runCatching {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -75,9 +75,6 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
-        launch(newSingleThreadContext("save-process")) {
-            startSaveProcess("cliArgs")
-        }
         val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()
     }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -94,11 +94,12 @@ class SaveAgent(internal val config: AgentConfiguration,
         logInfoCustom("Scheduling heartbeats")
 
         runBlocking {
+            val job2 = async { delay(15_000); logInfoCustom("Hi, I'm in a second launch") }
             val job1 = async(newSingleThreadContext("test-1")) {
                 logInfoCustom("Hi, I'm in a first launch")
-                system("sleep 20")
+                system("sleep 10")
+                job2.cancel()
             }
-            val job2 = async { delay(15_000); logInfoCustom("Hi, I'm in a second launch") }
             joinAll(job1, job2)
         }
 

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -39,8 +39,10 @@ import kotlin.native.concurrent.AtomicReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
@@ -50,6 +52,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
+import platform.posix.system
 
 /**
  * A main class for SAVE Agent
@@ -91,10 +94,12 @@ class SaveAgent(internal val config: AgentConfiguration,
         logInfoCustom("Scheduling heartbeats")
 
         runBlocking {
-            launch(newSingleThreadContext("test-1")) {
+            val job1 = async(newSingleThreadContext("test-1")) {
                 logInfoCustom("Hi, I'm in a first launch")
+                system("sleep 20")
             }
-            logInfoCustom("Hi, I'm in a second launch")
+            val job2 = async { delay(15_000); logInfoCustom("Hi, I'm in a second launch") }
+            joinAll(job1, job2)
         }
 
         sendDataToBackend { saveAdditionalData() }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -149,6 +149,10 @@ class SaveAgent(internal val config: AgentConfiguration,
         logInfoCustom("SAVE has completed execution with status ${executionResult.code}")
         val executionLogs = ExecutionLogs(config.id, readFile(config.logFilePath))
         val logsSendingJob = launchLogSendingJob(executionLogs)
+        logDebugCustom("SAVE has completed execution, execution logs:")
+        executionLogs.cliLogs.forEach {
+            logDebugCustom("[SAVE] $it")
+        }
         when (executionResult.code) {
             0 -> if (executionLogs.cliLogs.isEmpty()) {
                 state.value = AgentState.CLI_FAILED

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -75,6 +75,9 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
+        launch(newSingleThreadContext("save-process")) {
+            startSaveProcess("cliArgs")
+        }
         val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()
     }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -29,7 +29,6 @@ import io.ktor.http.contentType
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
-import kotlin.coroutines.CoroutineContext
 import kotlin.native.concurrent.AtomicLong
 import kotlin.native.concurrent.AtomicReference
 import kotlinx.coroutines.CoroutineScope
@@ -76,9 +75,6 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
-        launch(newSingleThreadContext("save-process")) {
-            startSaveProcess("cliArgs")
-        }
         val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()
     }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -85,6 +85,15 @@ class SaveAgent(internal val config: AgentConfiguration,
      */
     suspend fun start() = coroutineScope {
         logInfoCustom("Starting agent")
+
+        val job = launch(newSingleThreadContext("test")) {
+            logInfoCustom("Foo from test")
+//            executionStartSeconds.value = Clock.System.now().epochSeconds
+//            state.value = AgentState.CLI_FAILED
+            maybeStartSaveProcess("foo bar baz")
+        }
+        job.join()
+
         val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()
     }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -2,6 +2,9 @@
 
 package org.cqfn.save.agent
 
+import org.cqfn.save.agent.utils.logDebugCustom
+import org.cqfn.save.agent.utils.logErrorCustom
+import org.cqfn.save.agent.utils.logInfoCustom
 import org.cqfn.save.agent.utils.readFile
 import org.cqfn.save.agent.utils.sendDataToBackend
 import org.cqfn.save.core.logging.describe
@@ -47,8 +50,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import org.cqfn.save.agent.utils.logDebugCustom
-import org.cqfn.save.agent.utils.logInfoCustom
 
 /**
  * A main class for SAVE Agent
@@ -105,7 +106,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                     is ContinueResponse -> Unit  // do nothing
                 }
             } else {
-                logError("Exception during heartbeat: ${response.exceptionOrNull()?.message}")
+                logErrorCustom("Exception during heartbeat: ${response.exceptionOrNull()?.message}")
                 response.exceptionOrNull()?.printStackTrace()
             }
             // todo: start waiting after request was sent, not after response?
@@ -116,7 +117,7 @@ class SaveAgent(internal val config: AgentConfiguration,
 
     private suspend fun maybeStartSaveProcess(cliArgs: String) = coroutineScope {
         if (saveProcessJob?.isCompleted == false) {
-            logError("Shouldn't start new process when there is the previous running")
+            logErrorCustom("Shouldn't start new process when there is the previous running")
         } else {
             saveProcessJob = launch(
                 newSingleThreadContext("save-execution")
@@ -128,7 +129,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                     .exceptionOrNull()
                     ?.let {
                         state.value = AgentState.CLI_FAILED
-                        logError("Error executing SAVE: ${it.describe()}")
+                        logErrorCustom("Error executing SAVE: ${it.describe()}")
                     }
             }
         }
@@ -155,7 +156,7 @@ class SaveAgent(internal val config: AgentConfiguration,
                 state.value = AgentState.FINISHED
             }
             else -> {
-                logError("SAVE has exited abnormally with status ${executionResult.code}")
+                logErrorCustom("SAVE has exited abnormally with status ${executionResult.code}")
                 state.value = AgentState.CLI_FAILED
             }
         }
@@ -216,7 +217,7 @@ class SaveAgent(internal val config: AgentConfiguration,
         }
             .exceptionOrNull()
             ?.let {
-                logError("Couldn't send logs, reason: ${it.message}")
+                logErrorCustom("Couldn't send logs, reason: ${it.message}")
             }
     }
 
@@ -226,7 +227,7 @@ class SaveAgent(internal val config: AgentConfiguration,
             readExecutionResults(jsonReport)
         }
         if (testExecutionDtos.isFailure) {
-            logError("Couldn't read execution results from JSON report, reason: ${testExecutionDtos.exceptionOrNull()?.describe()}" +
+            logErrorCustom("Couldn't read execution results from JSON report, reason: ${testExecutionDtos.exceptionOrNull()?.describe()}" +
                     "\n${testExecutionDtos.exceptionOrNull()?.stackTraceToString()}"
             )
         } else {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/FileUtils.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/FileUtils.kt
@@ -22,7 +22,7 @@ internal fun readFile(filePath: String): List<String> = try {
         generateSequence { readUtf8Line() }.toList()
     }
 } catch (e: FileNotFoundException) {
-    logError("Not able to find file in the following path: $filePath")
+    logErrorCustom("Not able to find file in the following path: $filePath")
     emptyList()
 }
 

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/FileUtils.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/FileUtils.kt
@@ -4,8 +4,6 @@
 
 package org.cqfn.save.agent.utils
 
-import org.cqfn.save.core.logging.logError
-
 import okio.FileNotFoundException
 import okio.FileSystem
 import okio.Path.Companion.toPath

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/HttpUtils.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/HttpUtils.kt
@@ -30,7 +30,7 @@ internal suspend fun SaveAgent.sendDataToBackend(
         state.value = AgentState.BACKEND_UNREACHABLE
         "Backend is unreachable, ${result.exceptionOrNull()?.message}"
     }
-    logError("Cannot post data (x${attempt + 1}), will retry in ${config.retry.initialRetryMillis} ms. Reason: $reason")
+    logErrorCustom("Cannot post data (x${attempt + 1}), will retry in ${config.retry.initialRetryMillis} ms. Reason: $reason")
 }
 
 /**

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/HttpUtils.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/HttpUtils.kt
@@ -7,7 +7,6 @@ package org.cqfn.save.agent.utils
 import org.cqfn.save.agent.AgentState
 import org.cqfn.save.agent.RetryConfig
 import org.cqfn.save.agent.SaveAgent
-import org.cqfn.save.core.logging.logError
 
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
@@ -1,10 +1,17 @@
+/**
+ * Logging utilities for save-agent
+ */
+
+@file:Suppress("MISSING_KDOC_TOP_LEVEL", "MISSING_KDOC_ON_FUNCTION")
+
 package org.cqfn.save.agent.utils
+
+import platform.linux.__NR_gettid
+import platform.posix.syscall
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import platform.linux.__NR_gettid
-import platform.posix.syscall
 
 fun logErrorCustom(msg: String) = logMessage(
     "ERROR",

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
@@ -1,0 +1,14 @@
+package org.cqfn.save.agent.utils
+
+import org.cqfn.save.core.logging.logDebug
+import org.cqfn.save.core.logging.logInfo
+import platform.linux.__NR_gettid
+import platform.posix.syscall
+
+fun logInfoCustom(msg: String) = logInfo(
+    "${syscall(__NR_gettid.toLong())} $msg"
+)
+
+fun logDebugCustom(msg: String) = logDebug(
+    "${syscall(__NR_gettid.toLong())} $msg"
+)

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
@@ -6,35 +6,21 @@
 
 package org.cqfn.save.agent.utils
 
+import org.cqfn.save.core.logging.logDebug
+import org.cqfn.save.core.logging.logError
+import org.cqfn.save.core.logging.logInfo
+
 import platform.linux.__NR_gettid
 import platform.posix.syscall
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-
-fun logErrorCustom(msg: String) = logMessage(
-    "ERROR",
+fun logErrorCustom(msg: String) = logError(
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
 
-fun logInfoCustom(msg: String) = logMessage(
-    "INFO",
+fun logInfoCustom(msg: String) = logInfo(
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
 
-fun logDebugCustom(msg: String) = logMessage(
-    "DEBUG",
+fun logDebugCustom(msg: String) = logDebug(
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
-
-private fun logMessage(
-    level: String,
-    msg: String,
-) {
-    val currentTime = run {
-        val currentTimeInstance = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-        " ${currentTimeInstance.date} ${currentTimeInstance.hour}:${currentTimeInstance.minute}:${currentTimeInstance.second}"
-    }
-    println("[$level]$currentTime: $msg")
-}

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
@@ -1,19 +1,33 @@
 package org.cqfn.save.agent.utils
 
-import org.cqfn.save.core.logging.logDebug
-import org.cqfn.save.core.logging.logError
-import org.cqfn.save.core.logging.logInfo
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import platform.linux.__NR_gettid
 import platform.posix.syscall
 
-fun logErrorCustom(msg: String) = logError(
+fun logErrorCustom(msg: String) = logMessage(
+    "ERROR",
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
 
-fun logInfoCustom(msg: String) = logInfo(
+fun logInfoCustom(msg: String) = logMessage(
+    "INFO",
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
 
-fun logDebugCustom(msg: String) = logDebug(
+fun logDebugCustom(msg: String) = logMessage(
+    "DEBUG",
     "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
+
+private fun logMessage(
+    level: String,
+    msg: String,
+) {
+    val currentTime = run {
+        val currentTimeInstance = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        " ${currentTimeInstance.date} ${currentTimeInstance.hour}:${currentTimeInstance.minute}:${currentTimeInstance.second}"
+    }
+    println("[$level]$currentTime: $msg")
+}

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/utils/Logging.kt
@@ -1,14 +1,19 @@
 package org.cqfn.save.agent.utils
 
 import org.cqfn.save.core.logging.logDebug
+import org.cqfn.save.core.logging.logError
 import org.cqfn.save.core.logging.logInfo
 import platform.linux.__NR_gettid
 import platform.posix.syscall
 
+fun logErrorCustom(msg: String) = logError(
+    "[tid ${syscall(__NR_gettid.toLong())}] $msg"
+)
+
 fun logInfoCustom(msg: String) = logInfo(
-    "${syscall(__NR_gettid.toLong())} $msg"
+    "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )
 
 fun logDebugCustom(msg: String) = logDebug(
-    "${syscall(__NR_gettid.toLong())} $msg"
+    "[tid ${syscall(__NR_gettid.toLong())}] $msg"
 )


### PR DESCRIPTION
### What's done:
* More logging: log thread id in save-agent
* Run save in a separate single-threaded context (should lead to regular heartbeats while save is being executed)
* Add logs of save-cli into stdout of save-agent

Closes #315 