### PR TITLE
Redirect unauthorized requests from FE to login page

### DIFF
--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -5,11 +5,13 @@
 package org.cqfn.save.gateway.security
 
 import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
 import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler
 
 @EnableWebFluxSecurity
@@ -22,7 +24,7 @@ class WebSecurityConfig {
         // `CollectionView` is a public page
         // todo: backend should tell which endpoint is public, and gateway should provide user data
         authorizeExchange()
-            .pathMatchers("/", "/info/**", "/api/projects/not-deleted", "/save-frontend*.js*")
+            .pathMatchers("/", "/login", "/info/**", "/api/projects/not-deleted", "/save-frontend*.js*")
             .permitAll()
     }
         .and().run {
@@ -34,8 +36,15 @@ class WebSecurityConfig {
             // FixMe: Properly support CSRF protection https://github.com/diktat-static-analysis/save-cloud/issues/34
             csrf().disable()
         }
+        .exceptionHandling {
+            it.authenticationEntryPoint(
+                HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)
+            )
+        }
         .oauth2Login {
-            it.authenticationSuccessHandler(RedirectServerAuthenticationSuccessHandler("/#/projects"))
+            it.authenticationSuccessHandler(
+                RedirectServerAuthenticationSuccessHandler("/#/projects")
+            )
         }
         .build()
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
@@ -81,7 +81,14 @@ suspend fun request(url: String,
         credentials = credentials,
     )
 )
-    .await()
+    .await().also {
+        if (it.status == 401.toShort()) {
+            // if 401 - change current URL to /login
+            // fixme: this should happen if there is no logged in user on FE
+            // otherwise 401 means that the user has insufficient permissions
+            window.location.href = "${window.location.origin}/login"
+        }
+    }
 
 /**
  * @param name

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
@@ -83,10 +83,10 @@ suspend fun request(url: String,
 )
     .await().also {
         if (it.status == 401.toShort()) {
-            // if 401 - change current URL to /login
+            // if 401 - change current URL to the main page (with login screen)
             // fixme: this should happen if there is no logged in user on FE
             // otherwise 401 means that the user has insufficient permissions
-            window.location.href = "${window.location.origin}/login"
+            window.location.href = "${window.location.origin}/#"
         }
     }
 

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
@@ -84,8 +84,7 @@ suspend fun request(url: String,
     .await().also {
         if (it.status == 401.toShort()) {
             // if 401 - change current URL to the main page (with login screen)
-            // fixme: this should happen if there is no logged in user on FE
-            // otherwise 401 means that the user has insufficient permissions
+            // note: we may have other uses for 401 in the future
             window.location.href = "${window.location.origin}/#"
         }
     }


### PR DESCRIPTION
### What's done:
* Gateway: return 401 for unathorized requests instead of redirect to login
* Handle 401 on frontend - if any request fails with 401, redirect to main page
* After authentication, redirect to `/#/projects` instead of main page

Closes #443